### PR TITLE
Adição de Testes Unitários – Atividade Online 4

### DIFF
--- a/test/services/device_service_test.dart
+++ b/test/services/device_service_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:accessa_mobile/services/storage.dart';
+import 'package:accessa_mobile/services/device_service.dart';
+
+void main() {
+  // Garante binding inicializado para usar SharedPreferences em teste
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    // Zera o "banco" em memória antes de cada teste
+    SharedPreferences.setMockInitialValues({});
+    await Storage.init();
+  });
+
+  test('DeviceService.load retorna lista padrão quando não há dados salvos', () async {
+    // Act
+    final devices = await DeviceService.load();
+
+    // Assert
+    expect(devices.length, 3);
+    expect(devices[0]['id'], 'dev-101');
+    expect(devices[0]['name'], 'Laboratório 01');
+    expect(devices[0]['status'], 'online');
+  });
+
+  test('DeviceService.add adiciona um novo dispositivo à lista', () async {
+    // Arrange
+    final newDevice = {
+      'id': 'dev-200',
+      'name': 'Sala de Reunião',
+      'status': 'offline',
+    };
+
+    // Act
+    await DeviceService.add(newDevice);
+    final devices = await DeviceService.load();
+
+    // Assert
+    expect(devices.length, 4); // 3 defaults + 1 novo
+    expect(
+      devices.any((d) => d['id'] == 'dev-200' && d['name'] == 'Sala de Reunião'),
+      isTrue,
+    );
+  });
+}


### PR DESCRIPTION
## Descrição

Este Pull Request adiciona um conjunto completo de testes unitários ao projeto **Accessa Mobile**, com foco na validação de regras de negócio, consistência de dados e aumento da confiabilidade geral da aplicação.

Os testes implementados abrangem três áreas principais:

### 1. Testes para `fmtDateTime`
Arquivo: `test/utils/date_fmt_test.dart`

Este conjunto valida:
- Formatação da data no padrão `DD/MM/AAAA - HH:MM:SS`;
- Zeros à esquerda para dia, mês e horários menores que 10;
- Garantia de que o ano possui sempre quatro dígitos, evitando erro em datas históricas.

### 2. Testes para `MqttConfig`
Arquivo: `test/services/mqtt_config_test.dart`

Validações realizadas:
- Verificação do valor fixo de `baseTopic` (`"accessa"`);
- Garantia de que `clientId()` sempre retorna:
  - Prefixo `"accessa_"`;
  - Sufixo numérico válido (timestamp convertido em string).

### 3. Testes para `DeviceService`
Arquivo: `test/services/device_service_test.dart`

Testes implementados:
- `load()`: garante que, quando não há dados salvos, o método retorna corretamente a lista padrão de dispositivos definida na aplicação;
- `add()`: valida que um novo dispositivo é adicionado à lista e persistido corretamente, sendo retornado em leituras subsequentes.

Esta seção cobre o funcionamento interno do sistema de persistência via `Storage`, garantindo que dispositivos são carregados, armazenados e manipulados conforme o esperado.

---

## Tipo de Mudança

- [ ] feat – Nova funcionalidade  
- [ ] fix – Correção de bug  
- [ ] docs – Atualização de documentação  
- [ ] refactor – Refatoração sem alteração de comportamento  
- [x] test – Adição/ajuste de testes  
- [ ] chore – Atualizações gerais ou de dependências  

---

## Issues Relacionadas

Contribuição referente à Atividade Online 4.  
Nenhuma Issue específica vinculada.

---

## Como Testar

1. Certifique-se de estar na branch deste Pull Request:
   git checkout feat/testes-unitarios

2. Execute todos os testes da aplicação:
flutter test

3. Verifique a execução dos seguintes arquivos:
- test/utils/date_fmt_test.dart
- test/services/mqtt_config_test.dart
- test/services/device_service_test.dart

4. A saída esperada deve ser:
- All tests passed!